### PR TITLE
A few tweaks to make docs2csv play nice with stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ JPGs will be OCRd if -o set.
 
 **Typical usage** 
 
-    ruby docs2csv.rb -r -o directory-to-scan output.csv
+    ruby docs2csv.rb -r -o directory-to-scan [outputfile]
+
+If outputfile is omitted, `docs2csv` will write the CSV to `stdout`.
     
 This scans the directory recursively, and OCRs any PDFs which may need it. Other options:
 

--- a/docs2csv.rb
+++ b/docs2csv.rb
@@ -213,16 +213,17 @@ unless dirname = ARGV[0]
 	exit
 end
 
-unless options.outputfile = ARGV[1]
-	STDERR.write "ERROR: no output file specified\n"
-	exit
+if ARGV[1]
+    options.outputfile = File.open(ARGV[1], "w")
+else
+    options.outputfile = STDOUT
 end
 	
 # ------------------------------------------- Do it! ----------------------------------------
 
 # Open output CSV filename and write header
 if options.process
-	options.csv = CSV.open(options.outputfile,"w")
+	options.csv = CSV.new(options.outputfile)
 	options.csv << ["id", "text", "title", "url"]
 end
 


### PR DESCRIPTION
These changes allow a user to omit the `outputfile` parameter and instead have `docs2csv` pipe the CSV results to `stdout`. E.g.:

``` sh
ruby docs2csv.rb -r -o directory-to-scan > output.csv
```

p.s., Big thanks, @jstray, for this handy library! :tada:  
