### PR TITLE
Run Tika headlessly

### DIFF
--- a/docs2csv.rb
+++ b/docs2csv.rb
@@ -92,7 +92,7 @@ end
 # Extract text using Apache Tika. Handles many file formats, including MS Office, HTML
 def extractTextTika(filename)
 	execDir = File.expand_path(File.dirname(__FILE__))
-	text = `java -jar #{execDir}/tika-app-1.4.jar -t "#{filename}"` 
+	text = `java -Djava.awt.headless=true -jar #{execDir}/tika-app-1.4.jar -t "#{filename}"`
 end
 
 # extract text from specified file


### PR DESCRIPTION
Added `-Djava.awt.headless=true` flag to `java [...]` command so that, when processing lots of documents that require Tika, the "Tika CLI" application (on OSX, at least) doesn't keep popping into the foreground. Have not tested on Linux or Windows, but [doesn't appear to be platform-dependent](http://www.oracle.com/technetwork/articles/javase/headless-136834.html).
